### PR TITLE
Make bookmark creation not require mouse

### DIFF
--- a/README
+++ b/README
@@ -17,6 +17,10 @@ TODO:
 
 Update history
 --------------
+v3.2.1 (2011.02.22)
+1. If tagging by default, set the tags to be initial responder
+2. Add a key command to submit and close window 
+
 v3.2 (2010.05.14)
 1. change backgound.js to oo and add tests.
 

--- a/ui/BookmarkEditObject.js
+++ b/ui/BookmarkEditObject.js
@@ -4,6 +4,7 @@ function BookmarkEditObject(){
   this.title    = "Super class";
   this.command  = "command"
   this.key      = "add,edit,delete";
+  this.closeAfterSave = false;
 
   this.render0 = function(div){
     this.parentDiv = div;
@@ -65,6 +66,9 @@ function BookmarkEditObject(){
     		minChars: 0,
     		autoFill: true    
       });    
+      
+      // 
+    
   }
   this.resize = function(){}
   
@@ -101,7 +105,12 @@ function AfterBookmarkSaved(){
 	} else {
 		gbm_app.current_tabobj.btn_op.val("Saved.");
 		status_text("Bookmark Saved.");
-		gbm_app.reload();
+		
+		if( gbm_app.current_tabobj.closeAfterSave ){
+		  window.close()
+		}else{
+		  gbm_app.reload();		  
+		}
 	}
 }
 
@@ -140,6 +149,14 @@ function BookmarkAddObj(){
         gbm_app.current_tabobj.set_bookmark(bm,"Add");
       }
 	  
+      // set the 
+	    $('.ac_input').select()
+      $('.ac_input').keypress(function(e) {
+          if(e.keyCode == 13) {
+              $('input[type=button]').click()
+              gbm_app.current_tabobj.closeAfterSave = true;
+          }
+      });
 	});
   }
 }

--- a/ui/BookmarkEditObject.js
+++ b/ui/BookmarkEditObject.js
@@ -147,16 +147,18 @@ function BookmarkAddObj(){
         gbm_app.app_tabs.on_tab_show("edit");
       } else {
         gbm_app.current_tabobj.set_bookmark(bm,"Add");
+
+        // set the tags input as default then
+        // overrides the enter button but doesn't conflict with autocompletes
+  	    $('.ac_input').select()
+        $('.ac_input').keypress(function(e) {
+            if(e.keyCode == 13) {
+                $('input[type=button]').click()
+                gbm_app.current_tabobj.closeAfterSave = true;
+            }
+        });
       }
 	  
-      // set the 
-	    $('.ac_input').select()
-      $('.ac_input').keypress(function(e) {
-          if(e.keyCode == 13) {
-              $('input[type=button]').click()
-              gbm_app.current_tabobj.closeAfterSave = true;
-          }
-      });
 	});
   }
 }


### PR DESCRIPTION
Hello there, I added some defaults so that I don't have to move the mouse further than hitting the bookmark button. At some point that'll annoy me too, but I know that changing that involves making changes to the manifest that understandably people wouldn't want (It'd need access to run in the background in every webpage )
